### PR TITLE
Remove 'dnssec' commands that are no longer supported

### DIFF
--- a/testenv/docker/dns/files/etc-named.conf
+++ b/testenv/docker/dns/files/etc-named.conf
@@ -6,9 +6,7 @@ options {
 	allow-query     { localhost; 10.0.0.0/8; 172.17.0.0/16; 172.18.0.0/16; };
 	recursion yes;
 
-	dnssec-enable yes;
 	dnssec-validation yes;
-	dnssec-lookaside auto;
 
 	/* Path to ISC DLV key */
 	bindkeys-file "/etc/bind/bind.keys";


### PR DESCRIPTION
These commands are no longer supported (nor needed), thus causing issues when starting the DNS service:
https://github.com/grafana/gokrb5/actions/runs/9267229439/job/25493203737