### PR TITLE
Force CentOS 7 on krb5kdc Docker images

### DIFF
--- a/testenv/docker/krb5kdc-latest/Dockerfile
+++ b/testenv/docker/krb5kdc-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 EXPOSE 88
 

--- a/testenv/docker/krb5kdc-older/Dockerfile
+++ b/testenv/docker/krb5kdc-older/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 EXPOSE 88
 

--- a/testenv/docker/krb5kdc-res/Dockerfile
+++ b/testenv/docker/krb5kdc-res/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 EXPOSE 88
 ENTRYPOINT ["/usr/sbin/krb5kdc", "-n"]

--- a/testenv/docker/krb5kdc-shorttickets/Dockerfile
+++ b/testenv/docker/krb5kdc-shorttickets/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 EXPOSE 88
 EXPOSE 464

--- a/testenv/docker/krb5kdc-sub/Dockerfile
+++ b/testenv/docker/krb5kdc-sub/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 EXPOSE 88
 ENTRYPOINT ["/usr/sbin/krb5kdc", "-n"]

--- a/testenv/docker/krb5kdc/Dockerfile
+++ b/testenv/docker/krb5kdc/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 EXPOSE 88
 EXPOSE 464


### PR DESCRIPTION
Nowadays using `centos:latest` defaults to CentOS 8, and with that it causes some weird issues on `TestClient_AutoRenew_Goroutine`, like:
https://github.com/grafana/gokrb5/actions/runs/9272062697/job/25508929524